### PR TITLE
Fix erroneous option name in documentation (`--with-simd` -> `--enable-simd`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ git clone https://github.com/ZekunYin/RabbitMash.git
 cd RabbitMash
 ./bootstrap.sh
 ./configure [--prefix=...] [--with-capnp=...] [--with-gsl=...] \
-            [--with-simd=yes/no]
+            [--enable-simd=yes/no]
 make -j4
 #optional
 make install
@@ -72,7 +72,7 @@ git clone https://github.com/ZekunYin/RabbitMash.git
 cd RabbitMash
 ./bootstrap.sh
 ./configure [--prefix=...] [--with-capnp=...] [--with-gsl=...] \
-            [--with-simd=yes/no] [--enable-static-gsl=yes]     \
+            [--enable-simd=yes/no] [--enable-static-gsl=yes]     \
             [--enable-static-cpp=yes]
 make -j4
 #optional


### PR DESCRIPTION
This fixes the name of the simd instructions option in the documentation, which should be `--enable-simd` instead of `--with-simd`.

Configuring with `--with-simd` gives the following error:
```
[maklinto@r18c04 RabbitMash]$ ./configure --prefix=/projappl/project_2006181/RabbitMash/bin --with-capnp=/projappl/project_2006181/capnproto-c++-1.0.1/ --with-simd=yes --enable-static-gsl=no --enable-static-cpp=no
configure: WARNING: unrecognized options: --with-simd
```